### PR TITLE
Add Filter To Instance Fields

### DIFF
--- a/woocommerce-table-rate-shipping.php
+++ b/woocommerce-table-rate-shipping.php
@@ -322,6 +322,8 @@ if ( is_woocommerce_active() ) {
 						'placeholder' => __( 'n/a', 'woocommerce-table-rate-shipping' )
 					),
 				);
+				
+				$this->instance_fields = apply_filters( 'woocommerce_table_rate_instance_fields', $this->instance_fields );
 
 			}
 


### PR DESCRIPTION
This simple change to `init_form_fields()` will allow users to filter the fields using the filter `woocommerce_table_rate_instance_fields`, which can allow them to add their own custom fields.
